### PR TITLE
Added ability to build assets using Vite as an alternative to Webpack encore.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ RUN \
     # Build assets using Webpack Encore
     if [ -f node_modules/.bin/encore ]; then \
         node_modules/.bin/encore production; \
+    # Build assets using Vite
+    elif [ -f node_modules/.bin/vite ]; then \
+        node_modules/.bin/vite build; \
     fi;
 
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="#-license">License</a>
 </p>
 
-This project is inspired by [dunglas/symfony-docker](https://github.com/dunglas/symfony-docker), but it aims to be more **customizable** (while remaining **zero-config**) and enhance the **developer experience**. It includes support for Visual Studio Code **Dev Containers**, **MariaDB** and **Webpack Encore**.
+This project is inspired by [dunglas/symfony-docker](https://github.com/dunglas/symfony-docker), but it aims to be more **customizable** (while remaining **zero-config**) and enhance the **developer experience**. It includes support for Visual Studio Code **Dev Containers**, **MariaDB** and **Webpack Encore/Vite**.
 
 > **Warning**: this project is still under development, please use it for testing purposes and feel free to suggest changes and improvements.
 
@@ -37,6 +37,7 @@ This project is inspired by [dunglas/symfony-docker](https://github.com/dunglas/
 - ✅ [MariaDB](https://mariadb.com/products/community-server), automatic Doctrine `DATABASE_URL` parsing, migrations support
 - ✅ [Caddy](https://caddyserver.com) web server, automatic HTTPS and www to non-www redirection, HTTP/2, [Vulcain](https://vulcain.rocks) support
 - ✅ [Webpack Encore](https://github.com/symfony/webpack-encore) support
+- ✅ [Vite](https://github.com/lhapaipai/vite-bundle) support
 - ✅ PHP OPcache [preloading](https://www.php.net/manual/en/opcache.preloading.php) support
 - ✅ Docker pre-built multi-platform images for faster startup
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ This project is inspired by [dunglas/symfony-docker](https://github.com/dunglas/
 - ✅ Visual Studio Code [dev container](https://code.visualstudio.com/docs/devcontainers/containers), opinionated settings and extensions
 - ✅ [MariaDB](https://mariadb.com/products/community-server), automatic Doctrine `DATABASE_URL` parsing, migrations support
 - ✅ [Caddy](https://caddyserver.com) web server, automatic HTTPS and www to non-www redirection, HTTP/2, [Vulcain](https://vulcain.rocks) support
-- ✅ [Webpack Encore](https://github.com/symfony/webpack-encore) support
-- ✅ [Vite](https://github.com/lhapaipai/vite-bundle) support
+- ✅ [Webpack Encore](https://github.com/symfony/webpack-encore) and [Vite](https://github.com/lhapaipai/vite-bundle) support
 - ✅ PHP OPcache [preloading](https://www.php.net/manual/en/opcache.preloading.php) support
 - ✅ Docker pre-built multi-platform images for faster startup
 


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

- [x] I've read the [guidelines for contributing](https://github.com/gremo/symfony-sail/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)
- [x] I've ensured that all commits' message styles match [semantic commits](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)

#### Description

In my personal project, I'm using https://github.com/lhapaipai/vite-bundle and https://github.com/lhapaipai/vite-plugin-symfony instead of Webpack encore. This change builds assets via Vite when Webpack encore isn't available.
